### PR TITLE
update for upstream version of morris.js 0.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <upstream.version>0.5.0</upstream.version>
+        <upstream.version>0.5.1</upstream.version>
         <upstream.url>https://github.com/oesmith/morris.js/archive</upstream.url>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${upstream.version}</destDir>
         <requirejs>


### PR DESCRIPTION
to prepare a 0.5.1 webjar release.

Hope you'll accept the change and integrate it asap :)

Happy new year !

Regards, 

Olivier.
